### PR TITLE
Fixed bugs with elastic scattering physics and direction cosine calculations

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -43,10 +43,6 @@ def move_to_nearest_boundary(state, mediums, u, v, w, epsilon=1e-6):
         nearest_medium: The medium the particle is now inside.
     """
     x, y, z = state["x"], state["y"], state["z"]
-    #u = math.sin(state["theta"]) * math.cos(state["phi"])
-    #v = math.sin(state["theta"]) * math.sin(state["phi"])
-    #w = math.cos(state["theta"])
-    #print(f"This is from move_to_nearest_boundary: {u}, {v}, {w}")
     nearest_distance = float('inf')
     nearest_point = None
     nearest_medium = None

--- a/geometry.py
+++ b/geometry.py
@@ -29,7 +29,7 @@ def count_coordinates_in_boundary(coordinates, x_bounds, y_bounds, z_bounds):
     )
 
 
-def move_to_nearest_boundary(state, mediums, epsilon=1e-6):
+def move_to_nearest_boundary(state, mediums, u, v, w, epsilon=1e-6):
     """
     Moves the particle to the nearest boundary and applies a small offset to ensure it's within the next medium.
 
@@ -43,10 +43,10 @@ def move_to_nearest_boundary(state, mediums, epsilon=1e-6):
         nearest_medium: The medium the particle is now inside.
     """
     x, y, z = state["x"], state["y"], state["z"]
-    u = math.sin(state["theta"]) * math.cos(state["phi"])
-    v = math.sin(state["theta"]) * math.sin(state["phi"])
-    w = math.cos(state["theta"])
-
+    #u = math.sin(state["theta"]) * math.cos(state["phi"])
+    #v = math.sin(state["theta"]) * math.sin(state["phi"])
+    #w = math.cos(state["theta"])
+    #print(f"This is from move_to_nearest_boundary: {u}, {v}, {w}")
     nearest_distance = float('inf')
     nearest_point = None
     nearest_medium = None
@@ -117,3 +117,16 @@ def move_to_nearest_boundary(state, mediums, epsilon=1e-6):
         state["z"] += epsilon * w
 
     return state, nearest_medium
+
+
+def calculate_void_si_max(mediums):
+    # Find the void medium
+    void_medium = next((m for m in mediums if m.is_void), None)
+    if void_medium:
+        x_range = void_medium.x_bounds[1] - void_medium.x_bounds[0]
+        y_range = void_medium.y_bounds[1] - void_medium.y_bounds[0]
+        z_range = void_medium.z_bounds[1] - void_medium.z_bounds[0]
+        # Diagonal of the bounding box
+        si_max = math.sqrt(x_range**2 + y_range**2 + z_range**2)
+        return si_max
+    return float('inf')  # No void medium, no limit

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def main():
 
 
     # Simulate particles
-    num_particles = 100_000
+    num_particles = 10000
 
     rngs = [RNGHandler(seed=12345 + i) for i in range(num_particles)]
 
@@ -57,7 +57,7 @@ def main():
     # For tracking if a particle existed within a certain region (x_min, x_max, y_min, y_max, z_min, z_max)
     region_bounds = (14.9, 15.1, -15, 15, -15, 15)
 
-    track = False
+    track = True
     # Prepare arguments for multiprocessing
     args = [
         (state, reader, mediums, A, N, sampler, region_bounds, track, rng)

--- a/physics.py
+++ b/physics.py
@@ -2,11 +2,12 @@
 import math
 import numpy as np
 
-def calculate_mu_lab(mu_cm, E, E_prime, A):
-    term1 = mu_cm * math.sqrt(E_prime / E)
+def calculate_mu_lab(mu_cm, E, E_prime, E_cm_prime, A):
+    term1 = mu_cm * math.sqrt(E_cm_prime / E_prime)
     term2 = 1 / (A + 1) * math.sqrt(E / E_prime)
     mu_lab = term1 + term2
-    return max(min(mu_lab, 1.0), -1.0)
+    #print(mu_lab)
+    return mu_lab
 
 
 def calculate_E_cm_prime(initial_energy, A, sampler):
@@ -25,30 +26,30 @@ def calculate_E_cm_prime(initial_energy, A, sampler):
     E_cm_prime = 0.5 * m_n * v_l_cm**2
     return E_cm_prime
 
-def calculate_E_prime(E_cm_prime, initial_energy, A):
+def calculate_E_prime(E_cm_prime, initial_energy, A, rng):
     E = initial_energy
-    mu_cm = 2 * np.random.uniform(0, 1) - 1  # Isotropic distribution in CM frame
+    mu_cm = 2 * rng.uniform(0, 1) - 1  # Isotropic distribution in CM frame
 
     # Calculate E_prime (neutron energy in the lab frame after scattering)
     E_prime = E_cm_prime + (E + 2 * mu_cm * (A + 1) * math.sqrt(E * E_cm_prime)) / ((A + 1)**2)
     return E_prime, mu_cm
 
 # Example of how to use these functions
-def elastic_scattering(initial_energy, A, sampler):
+def elastic_scattering(initial_energy, A, sampler, rng):
     E_cm_prime = calculate_E_cm_prime(initial_energy, A, sampler)
-    E_prime, mu_cm = calculate_E_prime(E_cm_prime, initial_energy, A)
+    E_prime, mu_cm = calculate_E_prime(E_cm_prime, initial_energy, A, rng)
 
-    # Assuming calculate_mu_lab is a defined function
-    mu_lab = calculate_mu_lab(mu_cm, initial_energy, E_prime, A)
+    mu_lab = calculate_mu_lab(mu_cm, initial_energy, E_prime, E_cm_prime, A)
     return E_prime, mu_cm, mu_lab
 
 
-def sample_new_direction_cosines(u, v, w, mu_lab):
-    mu_lab = max(min(mu_lab, 1.0), -1.0)
-    phi = 2 * math.pi * np.random.random()
+def sample_new_direction_cosines(u, v, w, mu_lab, rng):
+    phi = 2 * math.pi * rng.random()
     root_term = math.sqrt(max(0, 1 - mu_lab**2))
     denom = math.sqrt(max(1e-8, 1 - w**2))
     u_new = mu_lab * u + root_term * (u * w * math.cos(phi) - v * math.sin(phi)) / denom
     v_new = mu_lab * v + root_term * (v * w * math.cos(phi) + u * math.sin(phi)) / denom
-    w_new = mu_lab * w - root_term * math.cos(phi) / denom
-    return u_new, v_new, w_new, phi, mu_lab
+    w_new = mu_lab * w - root_term * math.cos(phi) * denom
+    assert abs(u_new**2 + v_new**2 + w_new**2 - 1.0) < 1e-6
+    #print(u_new, v_new, w_new)
+    return u_new, v_new, w_new, phi

--- a/physics.py
+++ b/physics.py
@@ -51,5 +51,4 @@ def sample_new_direction_cosines(u, v, w, mu_lab, rng):
     v_new = mu_lab * v + root_term * (v * w * math.cos(phi) + u * math.sin(phi)) / denom
     w_new = mu_lab * w - root_term * math.cos(phi) * denom
     assert abs(u_new**2 + v_new**2 + w_new**2 - 1.0) < 1e-6
-    #print(u_new, v_new, w_new)
     return u_new, v_new, w_new, phi


### PR DESCRIPTION
Description:

- There were a couple of mistakes in the physics functions. Mostly small syntax mistakes or wrong variable is being used. Fixed and revised the equations and added an assert statement to ensure direction cosines add up to 1 after elastic scattering.

- Removed the recalculation of direction cosines within the move_to_nearest_Boundary function, it was the main reason particles are being moved to the shield back after scattering outside. The recalculation formula was different than the sampled formula, and hence it led to different results.
