### PR TITLE
fix(issue-20): count unique particles in region detection, not simula…

### DIFF
--- a/src/simulation.py
+++ b/src/simulation.py
@@ -65,9 +65,9 @@ def simulate_particle(state, reader, mediums, A, N, sampler, region_bounds=None,
         if region_bounds:
             x_min, x_max, y_min, y_max, z_min, z_max = region_bounds
             if x_min <= state["x"] <= x_max and y_min <= state["y"] <= y_max and z_min <= state["z"] <= z_max:
-if not state.get("was_in_region", False):
-                        region_count += 1
-                    state["was_in_region"] = True
+        if not state.get("was_in_region", False):
+            region_count += 1
+            state["was_in_region"] = True
         current_medium = None
         max_priority = -float('inf')
         for medium in mediums:
@@ -101,8 +101,6 @@ if not state.get("was_in_region", False):
                 state["y"] += epsilon * v
                 state["z"] += epsilon * w
             continue
-
-        #print("This is not printing")
 
         # Get cross-sections for the current medium
         sigma_s, sigma_a, sigma_f, Sigma_t = reader.get_cross_sections(


### PR DESCRIPTION
…tion steps  Fixes #20  Change region_count to only increment once when a particle first enters the detection region, instead of incrementing on every simulation step.  Implementation: - Track particle entry state with was_in_region flag in particle state dict - Only increment region_count when particle enters region for first time - Maintains state throughout single particle simulation  Behavior change: - Current: region_count increments on every step particle is in region - Fixed: region_count increments once per unique particle detection

Refactor region detection logic to track entry into regions more accurately.