### PR TITLE
Add per-isotope validation suite and fix Be9 (n,2n) child energy sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 Monte_Carlo_Shielding.egg-info/
 all_trajectories.json
 all_code.py
+CLAUDE.md
+.claude/

--- a/Validation/OpenMC_Comparison/_common.py
+++ b/Validation/OpenMC_Comparison/_common.py
@@ -1,0 +1,221 @@
+"""
+Shared utilities for PyNeut vs OpenMC validation scripts.
+
+All validate_*.py scripts import from here. Handles path setup,
+PyNeut simulation runner, statepoint reading, and result formatting.
+"""
+import os
+import sys
+import numpy as np
+from multiprocessing import Pool
+
+# ---------------------------------------------------------------------------
+# Path resolution — works when scripts are run from anywhere
+# ---------------------------------------------------------------------------
+HERE = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.abspath(os.path.join(HERE, '..', '..'))
+ENDF_PATH = os.path.join(PROJECT_ROOT, 'endfb')
+STATEPOINT_DIR = os.path.join(HERE, 'benchmark_diverse')
+
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.cross_section_read import CrossSectionReader
+from src.vt_calc import VelocitySampler
+from src.simulation import simulate_single_particle
+from src.material import Material
+from src.medium import Region, Sphere, Cylinder, Box, Plane
+from src.random_number_generator import RNGHandler
+from src.settings import Settings
+
+try:
+    import openmc
+    HAS_OPENMC = True
+except ImportError:
+    HAS_OPENMC = False
+
+# Lazy-loaded global reader — shared across all cases in a single run
+_reader = None
+
+def get_reader():
+    global _reader
+    if _reader is None:
+        _reader = CrossSectionReader(ENDF_PATH)
+    return _reader
+
+
+# ---------------------------------------------------------------------------
+# PyNeut runner
+# ---------------------------------------------------------------------------
+
+def run_pyneut(case, n_particles=10000):
+    """
+    Run a PyNeut shielding simulation for a test case dict.
+
+    Case dict keys:
+        el   : isotope name matching ENDF filename, e.g. 'Pb208'
+        rho  : density [g/cm3]
+        A    : atomic weight ratio
+        E    : source energy [eV]
+        geo  : 'sphere' | 'slab' | 'cyl'
+        dims : [radius] for sphere, [half-thickness] for slab,
+               [radius, half-height] for cyl (all in cm)
+
+    Returns (leakage_fraction, avg_escape_energy_eV).
+    """
+    reader = get_reader()
+    mat = Material(case['el'], case['rho'], case['A'], case['A'])
+    N = mat.number_density
+    A = case['A']
+
+    geo = case['geo']
+    if geo == 'sphere':
+        R = case['dims'][0]
+        mediums = [Region(
+            surfaces=[Sphere((0, 0, 0), R)],
+            operation='intersection', name='Sphere', priority=1, element=case['el'],
+        )]
+    elif geo == 'slab':
+        d = case['dims'][0]
+        mediums = [Region(
+            surfaces=[Box(-d, d, -50, 50, -50, 50)],
+            operation='intersection', name='Slab', priority=1, element=case['el'],
+        )]
+    elif geo == 'cyl':
+        R, H = case['dims']
+        mediums = [Region(
+            surfaces=[Cylinder('z', R, (0, 0, 0)), Plane(0, 0, 1, H), Plane(0, 0, -1, H)],
+            operation='intersection', name='Cyl', priority=1, element=case['el'],
+        )]
+    else:
+        raise ValueError(f"Unknown geometry: {geo!r}")
+
+    settings = Settings('shielding', n_particles)
+    rngs = [RNGHandler(12345 + i) for i in range(n_particles)]
+    states = [{
+        'x': 0.0, 'y': 0.0, 'z': 0.0,
+        'theta': np.arccos(1 - 2 * r.random()),
+        'phi': r.uniform(0, 2 * np.pi),
+        'has_interacted': False,
+        'energy': case['E'],
+        'weight': 1.0,
+    } for r in rngs]
+
+    try:
+        reader.get_inelastic_components(case['el'], case['E'], N)
+    except Exception:
+        pass
+
+    args = [
+        (s, reader, mediums, A, N, VelocitySampler(mat.kg_mass), None, False, r, settings)
+        for s, r in zip(states, rngs)
+    ]
+
+    with Pool() as pool:
+        results = pool.map(simulate_single_particle, args)
+
+    escaped = [(r['final_energy'], r['final_weight']) for r in results if r['final_weight'] > 0]
+    total_w = sum(w for _, w in escaped)
+    leakage = total_w / n_particles
+    avg_e = sum(e * w for e, w in escaped) / total_w if total_w > 0 else 0.0
+    return leakage, avg_e
+
+
+# ---------------------------------------------------------------------------
+# OpenMC statepoint reader
+# ---------------------------------------------------------------------------
+
+def read_statepoint(sp_path):
+    """
+    Read leakage fraction and average escape energy from a stored OpenMC
+    statepoint.  Requires the openmc Python package.
+
+    Expects tallies named 'leakage' and 'spectrum' (standard in all
+    benchmark_diverse runs).
+
+    Returns (leakage_fraction, avg_energy_eV) or (None, None) if openmc
+    is not installed or reading fails.
+    """
+    if not HAS_OPENMC:
+        return None, None
+    try:
+        with openmc.StatePoint(sp_path) as sp:
+            leak = sp.get_tally(name='leakage')
+            leak_val = float(np.sum(np.abs(leak.mean.flatten())))
+
+            spec = sp.get_tally(name='spectrum')
+            df = spec.get_pandas_dataframe()
+            df['E_mid'] = (df['energy low [eV]'] + df['energy high [eV]']) / 2
+            total_w = df['mean'].abs().sum()
+            avg_e = float((df['E_mid'] * df['mean'].abs()).sum() / total_w) if total_w > 0 else 0.0
+            return leak_val, avg_e
+    except Exception as e:
+        print(f'  [warn] statepoint read failed ({sp_path}): {e}')
+        return None, None
+
+
+# ---------------------------------------------------------------------------
+# Result formatting
+# ---------------------------------------------------------------------------
+
+# Thresholds for pass/fail
+_LEAKAGE_WARN = 1.0   # %
+_LEAKAGE_FAIL = 3.0   # %
+_ENERGY_WARN  = 2.0   # %
+_ENERGY_FAIL  = 5.0   # %
+
+
+def make_result(case_name, isotope, geometry, energy_mev,
+                omc_leak, omc_energy, pyn_leak, pyn_energy,
+                openmc_source='notebook'):
+    """
+    Build a result dict suitable for CSV output and terminal printing.
+
+    openmc_source values:
+        'notebook'   — hardcoded from prior notebook run
+        'statepoint' — read live from benchmark_diverse statepoint
+        'live'       — OpenMC was run on the fly
+        'N/A'        — no OpenMC reference available
+    """
+    if omc_leak is not None and omc_energy is not None and omc_energy > 0:
+        l_diff = abs(omc_leak - pyn_leak) / omc_leak * 100
+        e_diff = abs(omc_energy - pyn_energy) / omc_energy * 100
+        if l_diff <= _LEAKAGE_WARN and e_diff <= _ENERGY_WARN:
+            status = 'OK'
+        elif l_diff <= _LEAKAGE_FAIL and e_diff <= _ENERGY_FAIL:
+            status = 'WARNING'
+        else:
+            status = 'FAIL'
+    else:
+        l_diff = e_diff = None
+        status = 'NO_REF'
+
+    return {
+        'case':               case_name,
+        'isotope':            isotope,
+        'geometry':           geometry,
+        'energy_MeV':         energy_mev,
+        'openmc_leakage':     round(omc_leak, 5)  if omc_leak  is not None else None,
+        'pyneut_leakage':     round(pyn_leak, 5),
+        'leakage_diff_pct':   round(l_diff, 2)    if l_diff    is not None else None,
+        'openmc_energy_eV':   round(omc_energy)   if omc_energy is not None else None,
+        'pyneut_energy_eV':   round(pyn_energy),
+        'energy_diff_pct':    round(e_diff, 2)    if e_diff    is not None else None,
+        'openmc_source':      openmc_source,
+        'status':             status,
+    }
+
+
+def print_result(r):
+    tag = {'OK': '✓', 'WARNING': '!', 'FAIL': '✗', 'NO_REF': '?'}.get(r['status'], '?')
+    print(f"\n  [{tag}] {r['case']}")
+    print(f"      {'Metric':<22} {'OpenMC':>12}  {'PyNeut':>12}  {'Diff':>8}")
+    print(f"      {'-'*58}")
+
+    omc_l = f"{r['openmc_leakage']:.5f}"  if r['openmc_leakage']  is not None else 'N/A'
+    omc_e = f"{r['openmc_energy_eV']:,}"  if r['openmc_energy_eV'] is not None else 'N/A'
+    l_d   = f"{r['leakage_diff_pct']:.2f}%"  if r['leakage_diff_pct'] is not None else 'N/A'
+    e_d   = f"{r['energy_diff_pct']:.2f}%"   if r['energy_diff_pct']  is not None else 'N/A'
+
+    print(f"      {'Leakage fraction':<22} {omc_l:>12}  {r['pyneut_leakage']:>12.5f}  {l_d:>8}")
+    print(f"      {'Avg escape energy (eV)':<22} {omc_e:>12}  {r['pyneut_energy_eV']:>12,}  {e_d:>8}")
+    print(f"      source: {r['openmc_source']}")

--- a/Validation/OpenMC_Comparison/run_all.py
+++ b/Validation/OpenMC_Comparison/run_all.py
@@ -1,0 +1,112 @@
+"""
+Master validation runner — PyNeut vs OpenMC
+
+Runs all per-isotope validation scripts, collects results, and writes
+  validation_results.csv
+inside this directory.
+
+Usage
+-----
+  cd Validation/OpenMC_Comparison
+  python run_all.py [--n <particles>] [--skip-xs] [--isotopes Pb208,Fe56,...]
+
+Default: N=10 000 particles per case, all isotopes, XS check included.
+"""
+import argparse
+import csv
+import os
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import validate_Pb208
+import validate_Fe56
+import validate_Be9
+import validate_Al27
+import validate_C12
+import validate_O16
+import validate_xs
+
+CSV_PATH = os.path.join(HERE, 'validation_results.csv')
+
+_MODULES = {
+    'Pb208': validate_Pb208,
+    'Fe56':  validate_Fe56,
+    'Be9':   validate_Be9,
+    'Al27':  validate_Al27,
+    'C12':   validate_C12,
+    'O16':   validate_O16,
+}
+
+_CSV_FIELDS = [
+    'case', 'isotope', 'geometry', 'energy_MeV',
+    'openmc_leakage', 'pyneut_leakage', 'leakage_diff_pct',
+    'openmc_energy_eV', 'pyneut_energy_eV', 'energy_diff_pct',
+    'openmc_source', 'status',
+]
+
+
+def _banner(text):
+    bar = '=' * (len(text) + 4)
+    print(f'\n{bar}')
+    print(f'  {text}')
+    print(bar)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='PyNeut full validation suite')
+    parser.add_argument('--n', type=int, default=10_000,
+                        help='Particles per case (default 10 000)')
+    parser.add_argument('--skip-xs', action='store_true',
+                        help='Skip the cross-section interpolation check')
+    parser.add_argument('--isotopes', type=str, default='',
+                        help='Comma-separated subset, e.g. Pb208,Fe56')
+    args = parser.parse_args()
+
+    wanted = set(args.isotopes.split(',')) if args.isotopes else set(_MODULES)
+    wanted = {k for k in wanted if k}   # drop empty strings
+
+    all_results = []
+    t0 = time.time()
+
+    for name, mod in _MODULES.items():
+        if name not in wanted:
+            continue
+        _banner(f'{name} Validation  (N={args.n:,})')
+        results = mod.run(n_particles=args.n)
+        all_results.extend(results)
+
+    # XS check appends diagnostic rows with a different schema — write separately
+    if not args.skip_xs:
+        _banner('Cross-Section Interpolation Check')
+        validate_xs.run()
+
+    # -------------------------------------------------------------------------
+    # Summary table
+    # -------------------------------------------------------------------------
+    _banner('SUMMARY')
+    statuses = [r['status'] for r in all_results]
+    counts = {s: statuses.count(s) for s in ('OK', 'WARNING', 'FAIL', 'NO_REF')}
+    print(f"\n  {'Case':<28} {'Status':<10} {'Leakage diff':>14} {'Energy diff':>14}")
+    print(f"  {'-'*70}")
+    for r in all_results:
+        ld = f"{r['leakage_diff_pct']:.2f}%" if r['leakage_diff_pct'] is not None else 'N/A'
+        ed = f"{r['energy_diff_pct']:.2f}%"  if r['energy_diff_pct']  is not None else 'N/A'
+        print(f"  {r['case']:<28} {r['status']:<10} {ld:>14} {ed:>14}")
+    print(f"\n  OK={counts['OK']}  WARNING={counts['WARNING']}  FAIL={counts['FAIL']}  NO_REF={counts['NO_REF']}")
+    print(f"  Total time: {time.time()-t0:.1f}s")
+
+    # -------------------------------------------------------------------------
+    # Write CSV
+    # -------------------------------------------------------------------------
+    with open(CSV_PATH, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=_CSV_FIELDS, extrasaction='ignore')
+        writer.writeheader()
+        writer.writerows(all_results)
+    print(f'\n  Results written to: {os.path.relpath(CSV_PATH, HERE)}')
+
+
+if __name__ == '__main__':
+    main()

--- a/Validation/OpenMC_Comparison/validate_Al27.py
+++ b/Validation/OpenMC_Comparison/validate_Al27.py
@@ -1,0 +1,52 @@
+"""
+PyNeut vs OpenMC — Al27 validation cases
+
+Cases
+-----
+  al27_slab_1mev : Al27 thin slab half-thickness=0.5 cm, E=1 MeV
+
+Reference: hardcoded from Inelastic_Validations notebook.
+"""
+from _common import run_pyneut, make_result, print_result
+
+# ---------------------------------------------------------------------------
+# OpenMC reference (notebook, hardcoded)
+# ---------------------------------------------------------------------------
+_OMC = (0.9995, 933_522)   # leakage, avg_energy_eV
+
+# ---------------------------------------------------------------------------
+# Case definition
+# ---------------------------------------------------------------------------
+_CASE = {
+    'name': 'al27_slab_1mev',
+    'el':   'Al27',
+    'rho':  2.70,
+    'A':    26.982,
+    'E':    1e6,
+    'geo':  'slab',
+    'dims': [0.5],
+}
+
+
+def run(n_particles=10_000):
+    print(f"  Running {_CASE['name']} …")
+    pyn_leak, pyn_e = run_pyneut(_CASE, n_particles)
+    omc_leak, omc_e = _OMC
+    r = make_result(
+        case_name    = _CASE['name'],
+        isotope      = 'Al27',
+        geometry     = 'slab',
+        energy_mev   = 1.0,
+        omc_leak     = omc_leak,
+        omc_energy   = omc_e,
+        pyn_leak     = pyn_leak,
+        pyn_energy   = pyn_e,
+        openmc_source= 'notebook',
+    )
+    print_result(r)
+    return [r]
+
+
+if __name__ == '__main__':
+    print('\n=== Al27 Validation ===')
+    run()

--- a/Validation/OpenMC_Comparison/validate_Be9.py
+++ b/Validation/OpenMC_Comparison/validate_Be9.py
@@ -1,0 +1,57 @@
+"""
+PyNeut vs OpenMC — Be9 validation cases
+
+Cases
+-----
+  be9_n2n_14mev : Be9 sphere R=10 cm, E=14 MeV  ((n,2n) active)
+
+Reference: hardcoded from Inelastic_Validations notebook.
+
+Current status: FAIL — BUG 1 (energy too soft by ~4.4%).
+Root cause: child neutron in (n,2n) falls back to Maxwellian evaporation
+when rejection-sample fails 10 times.  The soft Maxwellian spectrum explains
+the cold escape energy.
+"""
+from _common import run_pyneut, make_result, print_result
+
+# ---------------------------------------------------------------------------
+# OpenMC reference (notebook, hardcoded)
+# ---------------------------------------------------------------------------
+_OMC = (1.5848, 5_558_926)   # leakage, avg_energy_eV
+
+# ---------------------------------------------------------------------------
+# Case definition
+# ---------------------------------------------------------------------------
+_CASE = {
+    'name': 'be9_n2n_14mev',
+    'el':   'Be9',
+    'rho':  1.848,
+    'A':    9.012,
+    'E':    14e6,
+    'geo':  'sphere',
+    'dims': [10.0],
+}
+
+
+def run(n_particles=10_000):
+    print(f"  Running {_CASE['name']} …")
+    pyn_leak, pyn_e = run_pyneut(_CASE, n_particles)
+    omc_leak, omc_e = _OMC
+    r = make_result(
+        case_name    = _CASE['name'],
+        isotope      = 'Be9',
+        geometry     = 'sphere',
+        energy_mev   = 14.0,
+        omc_leak     = omc_leak,
+        omc_energy   = omc_e,
+        pyn_leak     = pyn_leak,
+        pyn_energy   = pyn_e,
+        openmc_source= 'notebook',
+    )
+    print_result(r)
+    return [r]
+
+
+if __name__ == '__main__':
+    print('\n=== Be9 Validation ===')
+    run()

--- a/Validation/OpenMC_Comparison/validate_C12.py
+++ b/Validation/OpenMC_Comparison/validate_C12.py
@@ -1,0 +1,52 @@
+"""
+PyNeut vs OpenMC — C12 (graphite) validation cases
+
+Cases
+-----
+  c12_cyl_2mev : Graphite cylinder R=10 cm, H=20 cm (half-height=10), E=2 MeV
+
+Reference: hardcoded from Inelastic_Validations notebook.
+"""
+from _common import run_pyneut, make_result, print_result
+
+# ---------------------------------------------------------------------------
+# OpenMC reference (notebook, hardcoded)
+# ---------------------------------------------------------------------------
+_OMC = (1.0000, 1_003_104)   # leakage, avg_energy_eV
+
+# ---------------------------------------------------------------------------
+# Case definition
+# ---------------------------------------------------------------------------
+_CASE = {
+    'name': 'c12_cyl_2mev',
+    'el':   'C12',
+    'rho':  2.267,
+    'A':    12.011,
+    'E':    2e6,
+    'geo':  'cyl',
+    'dims': [10.0, 10.0],   # [radius_cm, half_height_cm]
+}
+
+
+def run(n_particles=10_000):
+    print(f"  Running {_CASE['name']} …")
+    pyn_leak, pyn_e = run_pyneut(_CASE, n_particles)
+    omc_leak, omc_e = _OMC
+    r = make_result(
+        case_name    = _CASE['name'],
+        isotope      = 'C12',
+        geometry     = 'cyl',
+        energy_mev   = 2.0,
+        omc_leak     = omc_leak,
+        omc_energy   = omc_e,
+        pyn_leak     = pyn_leak,
+        pyn_energy   = pyn_e,
+        openmc_source= 'notebook',
+    )
+    print_result(r)
+    return [r]
+
+
+if __name__ == '__main__':
+    print('\n=== C12 (Graphite) Validation ===')
+    run()

--- a/Validation/OpenMC_Comparison/validate_Fe56.py
+++ b/Validation/OpenMC_Comparison/validate_Fe56.py
@@ -1,0 +1,95 @@
+"""
+PyNeut vs OpenMC — Fe56 validation cases
+
+Cases
+-----
+  fe56_slab_14mev  : Fe56 slab half-thickness=2 cm, E=14 MeV
+                     Reference: hardcoded from Inelastic_Validations notebook
+  fe56_sphere_25kev: Fe56 sphere R=15 cm, E=25 keV (resonance region)
+                     Reference: live statepoint in benchmark_diverse/
+
+Both cases currently FAIL — BUG 2 (XS mismatch, likely missed inelastic MTs).
+"""
+import os
+from _common import run_pyneut, make_result, print_result, read_statepoint, STATEPOINT_DIR
+
+# ---------------------------------------------------------------------------
+# OpenMC reference — slab case (notebook, hardcoded)
+# ---------------------------------------------------------------------------
+_OMC_SLAB = (1.1003, 4_732_820)   # leakage, avg_energy_eV
+
+# ---------------------------------------------------------------------------
+# Statepoint path — sphere 25 keV (pre-computed, stored on disk)
+# ---------------------------------------------------------------------------
+_SP_SPHERE = os.path.join(STATEPOINT_DIR, 'openmc_Fe56_sphere', 'statepoint.20.h5')
+
+# ---------------------------------------------------------------------------
+# Case definitions
+# ---------------------------------------------------------------------------
+_CASE_SLAB = {
+    'name': 'fe56_slab_14mev',
+    'el':   'Fe56',
+    'rho':  7.87,
+    'A':    55.845,
+    'E':    14e6,
+    'geo':  'slab',
+    'dims': [2.0],
+}
+
+_CASE_SPHERE = {
+    'name': 'fe56_sphere_25kev',
+    'el':   'Fe56',
+    'rho':  7.87,
+    'A':    55.845,
+    'E':    25e3,
+    'geo':  'sphere',
+    'dims': [15.0],
+}
+
+
+def run(n_particles=10_000):
+    results = []
+
+    # --- slab 14 MeV --------------------------------------------------------
+    print(f"  Running {_CASE_SLAB['name']} …")
+    pyn_leak, pyn_e = run_pyneut(_CASE_SLAB, n_particles)
+    omc_leak, omc_e = _OMC_SLAB
+    r = make_result(
+        case_name    = _CASE_SLAB['name'],
+        isotope      = 'Fe56',
+        geometry     = 'slab',
+        energy_mev   = 14.0,
+        omc_leak     = omc_leak,
+        omc_energy   = omc_e,
+        pyn_leak     = pyn_leak,
+        pyn_energy   = pyn_e,
+        openmc_source= 'notebook',
+    )
+    print_result(r)
+    results.append(r)
+
+    # --- sphere 25 keV (statepoint) -----------------------------------------
+    print(f"  Running {_CASE_SPHERE['name']} …")
+    pyn_leak, pyn_e = run_pyneut(_CASE_SPHERE, n_particles)
+    omc_leak, omc_e = read_statepoint(_SP_SPHERE)
+    src = 'statepoint' if omc_leak is not None else 'N/A'
+    r = make_result(
+        case_name    = _CASE_SPHERE['name'],
+        isotope      = 'Fe56',
+        geometry     = 'sphere',
+        energy_mev   = 0.025,
+        omc_leak     = omc_leak,
+        omc_energy   = omc_e,
+        pyn_leak     = pyn_leak,
+        pyn_energy   = pyn_e,
+        openmc_source= src,
+    )
+    print_result(r)
+    results.append(r)
+
+    return results
+
+
+if __name__ == '__main__':
+    print('\n=== Fe56 Validation ===')
+    run()

--- a/Validation/OpenMC_Comparison/validate_O16.py
+++ b/Validation/OpenMC_Comparison/validate_O16.py
@@ -1,0 +1,55 @@
+"""
+PyNeut vs OpenMC — O16 validation cases
+
+Cases
+-----
+  o16_sphere_10mev : O16 sphere R=20 cm, density=0.0014 g/cm3, E=10 MeV
+
+Reference: pre-computed statepoint in benchmark_diverse/openmc_O16_sphere/.
+Parameters derived from model.xml: 500 particles × 20 batches = N=10 000.
+"""
+import os
+from _common import run_pyneut, make_result, print_result, read_statepoint, STATEPOINT_DIR
+
+# ---------------------------------------------------------------------------
+# Statepoint path
+# ---------------------------------------------------------------------------
+_SP = os.path.join(STATEPOINT_DIR, 'openmc_O16_sphere', 'statepoint.20.h5')
+
+# ---------------------------------------------------------------------------
+# Case definition
+# ---------------------------------------------------------------------------
+_CASE = {
+    'name': 'o16_sphere_10mev',
+    'el':   'O16',
+    'rho':  0.0014,
+    'A':    15.999,
+    'E':    10e6,
+    'geo':  'sphere',
+    'dims': [20.0],
+}
+
+
+def run(n_particles=10_000):
+    print(f"  Running {_CASE['name']} …")
+    pyn_leak, pyn_e = run_pyneut(_CASE, n_particles)
+    omc_leak, omc_e = read_statepoint(_SP)
+    src = 'statepoint' if omc_leak is not None else 'N/A'
+    r = make_result(
+        case_name    = _CASE['name'],
+        isotope      = 'O16',
+        geometry     = 'sphere',
+        energy_mev   = 10.0,
+        omc_leak     = omc_leak,
+        omc_energy   = omc_e,
+        pyn_leak     = pyn_leak,
+        pyn_energy   = pyn_e,
+        openmc_source= src,
+    )
+    print_result(r)
+    return [r]
+
+
+if __name__ == '__main__':
+    print('\n=== O16 Validation ===')
+    run()

--- a/Validation/OpenMC_Comparison/validate_Pb208.py
+++ b/Validation/OpenMC_Comparison/validate_Pb208.py
@@ -1,0 +1,71 @@
+"""
+PyNeut vs OpenMC — Pb208 validation cases
+
+Cases
+-----
+  pb208_elastic  : Pb208 sphere R=10 cm, E=2 MeV   (elastic-dominant)
+  pb208_n2n      : Pb208 sphere R=10 cm, E=14 MeV  ((n,2n) active)
+
+OpenMC reference values come from the Inelastic_Validations notebook
+(N=10 000, shielding mode, hardcoded here for reproducibility).
+"""
+from _common import run_pyneut, make_result, print_result
+
+# ---------------------------------------------------------------------------
+# OpenMC reference (notebook run, shielding mode, N=10000)
+# ---------------------------------------------------------------------------
+_OMC = {
+    'pb208_elastic': (0.9998,  1_962_031),
+    'pb208_n2n':     (1.5060,  5_275_196),
+}
+
+# ---------------------------------------------------------------------------
+# Case definitions
+# ---------------------------------------------------------------------------
+_CASES = [
+    {
+        'name':  'pb208_elastic',
+        'el':    'Pb208',
+        'rho':   11.35,
+        'A':     207.2,
+        'E':     2e6,
+        'geo':   'sphere',
+        'dims':  [10.0],
+    },
+    {
+        'name':  'pb208_n2n',
+        'el':    'Pb208',
+        'rho':   11.35,
+        'A':     207.2,
+        'E':     14e6,
+        'geo':   'sphere',
+        'dims':  [10.0],
+    },
+]
+
+
+def run(n_particles=10_000):
+    results = []
+    for case in _CASES:
+        print(f"  Running {case['name']} …")
+        pyn_leak, pyn_e = run_pyneut(case, n_particles)
+        omc_leak, omc_e = _OMC[case['name']]
+        r = make_result(
+            case_name    = case['name'],
+            isotope      = 'Pb208',
+            geometry     = case['geo'],
+            energy_mev   = case['E'] / 1e6,
+            omc_leak     = omc_leak,
+            omc_energy   = omc_e,
+            pyn_leak     = pyn_leak,
+            pyn_energy   = pyn_e,
+            openmc_source= 'notebook',
+        )
+        print_result(r)
+        results.append(r)
+    return results
+
+
+if __name__ == '__main__':
+    print('\n=== Pb208 Validation ===')
+    run()

--- a/Validation/OpenMC_Comparison/validate_xs.py
+++ b/Validation/OpenMC_Comparison/validate_xs.py
@@ -1,0 +1,131 @@
+"""
+Cross-section interpolation check — PyNeut vs h5py direct read
+
+Compares PyNeut's interpolated sigma_t, sigma_el, sigma_in at spot-check
+energies against values read straight from the ENDF HDF5 file via h5py.
+No OpenMC dependency.
+
+Isotopes checked: Pb208, Fe56, Be9, Al27, C12, O16
+"""
+import os
+import sys
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.abspath(os.path.join(HERE, '..', '..'))
+ENDF_PATH = os.path.join(PROJECT_ROOT, 'endfb')
+
+sys.path.insert(0, PROJECT_ROOT)
+
+try:
+    import h5py
+    HAS_H5PY = True
+except ImportError:
+    HAS_H5PY = False
+    print('[warn] h5py not installed — XS validation skipped')
+
+from _common import get_reader
+
+# ---------------------------------------------------------------------------
+# Spot-check energies per isotope [eV]
+# ---------------------------------------------------------------------------
+_CHECKS = {
+    'Pb208': [1e6, 2e6, 5e6, 14e6],
+    'Fe56':  [1e5, 1e6, 5e6, 14e6],
+    'Be9':   [1e6, 5e6, 14e6],
+    'Al27':  [1e5, 1e6, 5e6],
+    'C12':   [1e6, 2e6, 5e6],
+    'O16':   [1e6, 5e6, 10e6],
+}
+
+# ENDF MT numbers for total, elastic, inelastic
+_MT_TOTAL    = 1
+_MT_ELASTIC  = 2
+_MT_INELASTIC = 4   # sum of discrete + continuum
+
+
+def _read_h5_xs(isotope, mt, energy_ev):
+    """Interpolate a single reaction XS from the HDF5 file directly."""
+    fpath = os.path.join(ENDF_PATH, 'neutron', f'{isotope}.h5')
+    if not os.path.exists(fpath):
+        return None
+    with h5py.File(fpath, 'r') as f:
+        root = f'neutron/{isotope}'
+        rxn_key = f'reaction_{mt:03d}'
+        try:
+            grp = f[f'{root}/reactions/{rxn_key}']
+            xs_grp = grp['xs/294K'] if '294K' in grp.get('xs', {}) else grp['xs']
+            energies = xs_grp['energy'][:]
+            values   = xs_grp['value'][:]
+        except KeyError:
+            return None
+    return float(np.interp(energy_ev, energies, values))
+
+
+def _pyneut_xs(reader, isotope, energy_ev):
+    """Return (sigma_t, sigma_el, sigma_in) from PyNeut's reader."""
+    try:
+        sigma_t  = reader.get_total_cross_section(isotope, energy_ev)
+        sigma_el = reader.get_elastic_cross_section(isotope, energy_ev)
+        sigma_in = reader.get_inelastic_cross_section(isotope, energy_ev)
+        return sigma_t, sigma_el, sigma_in
+    except Exception as e:
+        return None, None, None
+
+
+def run():
+    if not HAS_H5PY:
+        print('  Skipping XS validation (h5py missing)')
+        return []
+
+    reader = get_reader()
+    results = []
+    warn_threshold = 1.0   # %
+
+    print(f'\n  {"Isotope":<8} {"Energy":>10}  {"MT":<4} {"h5py":>12} {"PyNeut":>12} {"Diff":>8}')
+    print(f'  {"-"*60}')
+
+    all_ok = True
+    for isotope, energies in _CHECKS.items():
+        for E in energies:
+            pyn_t, pyn_el, pyn_in = _pyneut_xs(reader, isotope, E)
+
+            for mt_label, mt, pyn_val in [
+                ('tot', _MT_TOTAL,     pyn_t),
+                ('el',  _MT_ELASTIC,   pyn_el),
+                ('in',  _MT_INELASTIC, pyn_in),
+            ]:
+                ref = _read_h5_xs(isotope, mt, E)
+                if ref is None or pyn_val is None:
+                    diff_str = 'N/A'
+                    ok = True
+                else:
+                    diff = abs(ref - pyn_val) / ref * 100 if ref > 0 else 0.0
+                    diff_str = f'{diff:.3f}%'
+                    ok = diff <= warn_threshold
+                    if not ok:
+                        all_ok = False
+
+                flag = '' if ok else ' !'
+                e_str = f'{E/1e6:.3f} MeV'
+                ref_str  = f'{ref:.5e}'  if ref     is not None else 'N/A'
+                pyn_str  = f'{pyn_val:.5e}' if pyn_val is not None else 'N/A'
+                print(f'  {isotope:<8} {e_str:>10}  {mt_label:<4} {ref_str:>12} {pyn_str:>12} {diff_str:>8}{flag}')
+
+                results.append({
+                    'isotope': isotope,
+                    'energy_eV': E,
+                    'mt': mt_label,
+                    'h5py_xs': ref,
+                    'pyneut_xs': pyn_val,
+                    'diff_pct': None if ref is None or pyn_val is None else
+                                abs(ref - pyn_val) / ref * 100 if ref > 0 else 0.0,
+                })
+
+    print(f'\n  Overall XS check: {"PASS" if all_ok else "FAIL (see ! rows)"}')
+    return results
+
+
+if __name__ == '__main__':
+    print('\n=== Cross-Section Interpolation Check ===')
+    run()

--- a/Validation/check_angle_data.py
+++ b/Validation/check_angle_data.py
@@ -1,0 +1,39 @@
+import h5py
+import os
+
+# Adjust path if needed
+base_path = "endfb/neutron"
+files_to_check = [("Fe56.h5", 91), ("Be9.h5", 16)]
+
+for fname, mt in files_to_check:
+    path = os.path.join(base_path, fname)
+    if not os.path.exists(path): continue
+
+    print(f"\n--- Inspecting {fname} MT={mt} ---")
+    try:
+        with h5py.File(path, 'r') as f:
+            # Find root
+            if f"neutron/{fname.split('.')[0]}" in f: root = f[f"neutron/{fname.split('.')[0]}"]
+            elif fname.split('.')[0] in f: root = f[fname.split('.')[0]]
+            else: print("Root not found"); continue
+
+            # Find Distribution
+            dist_path = f"reactions/reaction_{mt:03}/product_0/distribution_0"
+            if dist_path not in root: print("Distribution not found"); continue
+
+            grp = root[dist_path]
+            print(f"Group Keys: {list(grp.keys())}")
+
+            # Check Energy Attributes
+            if "energy" in grp:
+                print(f"Energy Dataset Attributes: {list(grp['energy'].attrs.keys())}")
+
+            # Check Group Attributes
+            print(f"Group Attributes: {list(grp.attrs.keys())}")
+
+            # Check if offsets exist as a dataset
+            if "offsets" in grp:
+                print("Found 'offsets' as a separate Dataset!")
+
+    except Exception as e:
+        print(f"Error: {e}")

--- a/Validation/data_check.py
+++ b/Validation/data_check.py
@@ -1,0 +1,56 @@
+import h5py
+import numpy as np
+import os
+
+BASE_PATH = "endfb"
+TARGET = "Fe56"
+
+def check_high_energy_structure():
+    fpath = os.path.join(BASE_PATH, "neutron", f"{TARGET}.h5")
+    if not os.path.exists(fpath): return
+
+    with h5py.File(fpath, 'r') as f:
+        # Navigate to distribution
+        root = f"neutron/{TARGET}" if f"neutron/{TARGET}" in f else TARGET
+        base = f"{root}/reactions/reaction_016/product_0/distribution_0"
+
+        # Load Incident Energy to find the 14 MeV index
+        E_in = f[base]["energy"][:]
+        offsets = f[base]["offsets"] if "offsets" in f[base] else f[base]["energy_out"].attrs["offsets"]
+
+        # Find 14 MeV bin
+        idx = np.searchsorted(E_in, 14.0e6)
+        # Check surrounding bins to be safe
+        idx = min(idx, len(E_in) - 2)
+
+        print(f"📊 Analyzing {TARGET} at E_in = {E_in[idx]/1e6:.1f} MeV (Index {idx})")
+
+        start = offsets[idx]
+        end = offsets[idx+1]
+
+        # Load the Energy Out block for this high-energy neutron
+        dset_out = f[base]["energy_out"]
+        block = dset_out[:, start:end]
+
+        print(f"   Block Size: {block.shape[1]} outgoing energy points")
+
+        # Inspect Row 3 and Row 4 for the HIGHEST outgoing energy (most anisotropic)
+        # Usually the last points in the block
+        print("\n   Checking last 5 outgoing energy points (Highest E'):")
+        print(f"   {'E_out':<12} | {'Row 3 (Val)':<12} | {'Row 4 (Val)':<12}")
+        print("-" * 45)
+
+        for i in range(max(0, block.shape[1]-5), block.shape[1]):
+            e_val = block[0, i]
+            r3    = int(block[3, i])
+            r4    = int(block[4, i])
+            print(f"   {e_val:<12.2e} | {r3:<12} | {r4:<12}")
+
+        print("\n   [ANALYSIS]")
+        r3_max = np.max(block[3, :])
+        if r3_max > 5:
+            print(f"   🚨 ROW 3 CHANGES! Max value is {r3_max}. It is the LENGTH.")
+        else:
+            print(f"   ✅ Row 3 stays small ({r3_max}). It is likely the FLAG.")
+
+check_high_energy_structure()

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -269,34 +269,25 @@ def run_particle_kernel(state, reader, mediums, A, N, sampler, region_bounds, tr
                     # ---------------------------------------------------------
 
                     if selected_mt == 16:  # (n,2n) -> 1 Child
-                        E_remaining = max(1e-5, E_avail - E_prime)
-
-                        child_E = 0.0
-                        child_valid = False
-
-                        # Try to sample child from real distribution
-                        for _ in range(10):
-                            # Try Law 61
-                            E_c, mu_c, succ_c = reader.get_secondary_correlated_sample(
+                        # Sample child independently from the same ENDF distribution as the
+                        # parent — no E_c <= E_remaining constraint.  The original constraint
+                        # caused systematic rejection when E_remaining was small (parent took
+                        # a large share), forcing the Maxwellian fallback and a soft spectrum.
+                        # OpenMC samples both neutrons from the distribution independently;
+                        # per-event energy conservation is not enforced.
+                        child_E, _, succ_c = reader.get_secondary_correlated_sample(
+                            current_medium.element, selected_mt, E_in_snapshot, rng
+                        )
+                        if not succ_c:
+                            child_E_uncorr = reader.get_secondary_energy(
                                 current_medium.element, selected_mt, E_in_snapshot, rng
                             )
-                            # Try Law 4
-                            if not succ_c:
-                                E_c_uncorr = reader.get_secondary_energy(current_medium.element, selected_mt, E_in_snapshot, rng)
-                                if E_c_uncorr is not None:
-                                    E_c = E_c_uncorr
-                                    succ_c = True
-
-                            if succ_c and E_c <= E_remaining:
-                                child_E = E_c
-                                child_valid = True
-                                break
-
-                        # Fallback Child
-                        if not child_valid:
-                            T_nuc = get_nuclear_temperature(E_remaining, A)
+                            if child_E_uncorr is not None:
+                                child_E = child_E_uncorr
+                                succ_c = True
+                        if not succ_c:
+                            T_nuc = get_nuclear_temperature(E_avail, A)
                             child_E = sample_maxwellian(T_nuc, rng)
-                            child_E = min(child_E, E_remaining)
 
                         child = state.copy()
                         child["energy"] = max(1e-5, child_E)


### PR DESCRIPTION
Validation suite (Validation/OpenMC_Comparison/):
- _common.py: shared runner, statepoint reader, result formatter
- validate_Pb208/Fe56/Be9/Al27/C12/O16.py: per-isotope scripts, each runnable standalone or importable by run_all.py
- validate_xs.py: h5py vs PyNeut XS interpolation spot-check
- run_all.py: master runner that writes validation_results.csv
- check_angle_data.py / data_check.py: Fe56 HDF5 structure diagnostics

Bug fix (simulation.py):

BUG Be9 (n,2n) child energy: Previously the child neutron sampled from the ENDF distribution with a hard rejection constraint E_c <= E_avail - E_prime. When the parent took a large energy share, E_remaining was small, all 10 attempts failed, and the child fell back to a soft Maxwellian evaporation spectrum making escaped neutrons ~4.4% too cold. 

Fix: sample child independently from the same ENDF distribution as the parent (no constraint).


Result: energy diff 4.37% FAIL -> 1.31% OK; leakage 0.20% -> 2.15% WARNING.
