### PR TITLE
Vector engine: shared cross-section search + multiprocessing

### DIFF
--- a/Validation/OpenMC_Comparison/benchmark_pincell_vector.py
+++ b/Validation/OpenMC_Comparison/benchmark_pincell_vector.py
@@ -54,53 +54,85 @@ def pellet_source_arrays(n, rng):
     }
 
 
+def _compare_to_refs(k, sem, label):
+    if not os.path.exists(REF_JSON):
+        return
+    ref = json.load(open(REF_JSON))
+    kp, sp = ref['pyneut_mean'], ref['pyneut_sem']
+    ko, so = ref['openmc_mean'], ref['openmc_sem']
+    print(f"\n  {label} k_inf = {k:.5f} ± {sem:.5f}")
+    print(f"  vs scalar PyNeut 5-seed ref {kp:.5f} ± {sp:.5f} : "
+          f"dk = {1e5 * (k - kp):+,.0f} pcm, z = {abs(k-kp)/np.hypot(sem,sp):.2f}")
+    print(f"  vs OpenMC 5-seed ref        {ko:.5f} ± {so:.5f} : "
+          f"dk = {1e5 * (k - ko):+,.0f} pcm, z = {abs(k-ko)/np.hypot(sem,so):.2f}")
+
+
 def main():
     ap = argparse.ArgumentParser(description='Vector-engine BEAVRS pin cell')
     ap.add_argument('--n', type=int, default=3000, help='neutrons/generation')
     ap.add_argument('--gens', type=int, default=140, help='total generations')
     ap.add_argument('--inactive', type=int, default=40, help='inactive generations')
     ap.add_argument('--seed', type=int, default=1)
+    ap.add_argument('--seeds', type=int, default=1,
+                    help='number of independent replicas (>1 runs them in '
+                         'parallel, one per core, and reports the seed-spread '
+                         'error bar)')
+    ap.add_argument('--workers', type=int, default=None,
+                    help='parallel workers (default: one per replica)')
     ap.add_argument('--quick', action='store_true', help='fast smoke test')
     args = ap.parse_args()
     if args.quick:
         args.n, args.gens, args.inactive = 500, 30, 10
 
-    print(f"\nVector-engine BEAVRS HZP pin cell (matched physics: free-gas H, "
-          f"294 K, no S(a,b))\n  N={args.n}/gen, {args.gens} gens, "
-          f"{args.inactive} inactive, seed={args.seed}\n")
-
     matched = build_openmc_materials(temperature=294.0, thermal=False)
     comps = {k: pyneut_composition(m, 294.0) for k, m in matched.items()}
     mediums = pyneut_mediums(comps)
-    reader = CrossSectionReader(ENDF_PATH, temperature='294K')
     settings = Settings('criticality', 1)
 
-    src = pellet_source_arrays(args.n, np.random.default_rng(args.seed))
+    print(f"\nVector-engine BEAVRS HZP pin cell (matched physics: free-gas H, "
+          f"294 K, no S(a,b))\n  N={args.n}/gen, {args.gens} gens, "
+          f"{args.inactive} inactive")
 
+    if args.seeds > 1:
+        # independent replications, one power iteration per core
+        seeds = [args.seed + i for i in range(args.seeds)]
+        sources = [pellet_source_arrays(args.n, np.random.default_rng(1000 + s))
+                   for s in seeds]
+        print(f"  {args.seeds} independent seeds in parallel "
+              f"({args.workers or args.seeds} workers)\n")
+        t0 = time.perf_counter()
+        out = vt.run_keff_parallel(ENDF_PATH, mediums, sources, settings, seeds,
+                                   generations=args.gens, inactive=args.inactive,
+                                   n_workers=args.workers)
+        dt = time.perf_counter() - t0
+        n_hist = args.n * args.gens * args.seeds
+        ks = out['per_seed_k']
+        print("  per-seed k_inf : " + "  ".join(f"{k:.5f}" for k in ks))
+        print(f"  wall time      : {dt:.1f} s for {n_hist:,} histories "
+              f"across {args.seeds} replicas = {n_hist / dt:,.0f} hist/s")
+        _compare_to_refs(out['k_mean'], out['k_spread_sem'],
+                         f"{args.seeds}-seed mean (seed-spread SEM):")
+        print("  (seed-spread SEM is the honest error bar for this DR~1 lattice)")
+        return
+
+    src = pellet_source_arrays(args.n, np.random.default_rng(args.seed))
+    print(f"  single seed={args.seed}\n")
     t0 = time.perf_counter()
-    out = vt.run_keff_vector(reader, mediums, src, settings,
+    out = vt.run_keff_vector(reader_single(), mediums, src, settings,
                              generations=args.gens, inactive=args.inactive,
                              seed=args.seed)
     dt = time.perf_counter() - t0
     n_hist = args.n * args.gens
-
     print(f"  k_inf (collision) : {out['k_eff']:.5f} ± {out['k_sem']:.5f}")
     print(f"  k_inf (source)    : {out['k_source']:.5f} ± {out['k_source_sem']:.5f}")
     print(f"  wall time         : {dt:.1f} s for {n_hist:,} histories "
           f"= {n_hist / dt:,.0f} hist/s (single core)")
+    _compare_to_refs(out['k_eff'], out['k_sem'], "single-seed")
+    print("  (single-seed run; the DR~1 lattice inflates single-run variance)")
 
-    if os.path.exists(REF_JSON):
-        ref = json.load(open(REF_JSON))
-        kp, sp = ref['pyneut_mean'], ref['pyneut_sem']
-        ko, so = ref['openmc_mean'], ref['openmc_sem']
-        zs = abs(out['k_eff'] - kp) / np.hypot(out['k_sem'], sp)
-        zo = abs(out['k_eff'] - ko) / np.hypot(out['k_sem'], so)
-        print(f"\n  vs scalar PyNeut 5-seed ref {kp:.5f} ± {sp:.5f} : "
-              f"dk = {1e5 * (out['k_eff'] - kp):+,.0f} pcm, z = {zs:.2f}")
-        print(f"  vs OpenMC 5-seed ref        {ko:.5f} ± {so:.5f} : "
-              f"dk = {1e5 * (out['k_eff'] - ko):+,.0f} pcm, z = {zo:.2f}")
-        print("  (single-seed run; the DR~1 lattice inflates single-run "
-              "variance — seed-spread SEMs are the honest error bar)")
+
+def reader_single():
+    return CrossSectionReader(ENDF_PATH, temperature='294K')
 
 
 if __name__ == '__main__':

--- a/src/vector_transport.py
+++ b/src/vector_transport.py
@@ -12,21 +12,45 @@ and cross-section lookups here must match it exactly (they are deterministic),
 while full transport is compared statistically, because the per-history order
 of RNG consumption necessarily differs between the two engines.
 
-Current scope (milestone 1): geometry, cross sections, free flights, and
-boundary crossings with transmission/specular reflection. A collision
-terminates the history and is scored as "collided", which is exactly the
-estimator a Beer-Lambert uncollided-transmission measurement needs. Collision
-physics (elastic, free-gas thermal, inelastic, (n,xn)) arrives in the next
-milestones.
+Scope: the full fixed-source and criticality physics of the per-history kernel
+(elastic with tabulated angular data, free-gas thermal motion, discrete
+inelastic, (n,xn) multiplication, URR self-shielding, analog fission banking
+and the k-eigenvalue driver), plus multiprocessing wrappers that run
+independent bank chunks (fixed source) or independent seeds (k-eigenvalue) one
+per core.
 """
 import numpy as np
 
 from .angular_distribution import AngularDistribution
+from .cross_section_read import CrossSectionReader
 from .geometry import get_primitive_surfaces
 from .medium import Plane, Sphere, Cylinder
 from .simulation import THERMAL_KINEMATICS_CUTOFF
 
 EPSILON = 1e-6  # boundary-crossing nudge, matches the scalar kernel
+
+
+def _interp_shared(E, grid, arrays):
+    """Clamped lin--lin interpolation of several y-arrays sharing one grid, at
+    the same energies, with a SINGLE ``searchsorted`` reused across all of them.
+
+    Reproduces ``np.interp`` (constant extrapolation past both ends) and the
+    scalar reader's ``_locate``/``_read`` form ``y[j-1] + frac*(y[j]-y[j-1])``,
+    so the four reaction channels are read with one grid search instead of one
+    per channel. Returns a list of interpolated arrays, one per entry of
+    ``arrays``.
+    """
+    j = np.clip(np.searchsorted(grid, E, side="right"), 1, len(grid) - 1)
+    lo = grid[j - 1]
+    denom = grid[j] - lo
+    safe = denom != 0.0
+    frac = np.clip(np.where(safe, (E - lo) / np.where(safe, denom, 1.0), 0.0),
+                   0.0, 1.0)
+    out = []
+    for y in arrays:
+        a = y[j - 1]
+        out.append(a + frac * (y[j] - a))
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -273,11 +297,13 @@ class VectorXS:
         Sfis = np.zeros_like(E)
         for iso, tbl in self.nuclides:
             scale = 1e-24 * iso.number_density
-            g = tbl["grid"]
-            Sel += np.interp(E, g, tbl["el"]) * scale
-            Sin += np.interp(E, g, tbl["in"]) * scale
-            Scap += np.interp(E, g, tbl["cap"]) * scale
-            Sfis += np.interp(E, g, tbl["fis"]) * scale
+            # one grid search shared by all four reaction channels
+            el, inl, cap, fis = _interp_shared(
+                E, tbl["grid"], (tbl["el"], tbl["in"], tbl["cap"], tbl["fis"]))
+            Sel += el * scale
+            Sin += inl * scale
+            Scap += cap * scale
+            Sfis += fis * scale
         return Sel, Sin, Scap, Sfis, Sel + Sin + Scap + Sfis
 
     def per_nuclide(self, energy):
@@ -289,11 +315,13 @@ class VectorXS:
         el, inl, cap, fis = [], [], [], []
         for iso, tbl in self.nuclides:
             scale = 1e-24 * iso.number_density
-            g = tbl["grid"]
-            el.append(np.interp(E, g, tbl["el"]) * scale)
-            inl.append(np.interp(E, g, tbl["in"]) * scale)
-            cap.append(np.interp(E, g, tbl["cap"]) * scale)
-            fis.append(np.interp(E, g, tbl["fis"]) * scale)
+            # one grid search shared by all four reaction channels
+            e, i, c, f = _interp_shared(
+                E, tbl["grid"], (tbl["el"], tbl["in"], tbl["cap"], tbl["fis"]))
+            el.append(e * scale)
+            inl.append(i * scale)
+            cap.append(c * scale)
+            fis.append(f * scale)
         return np.stack(el), np.stack(inl), np.stack(cap), np.stack(fis)
 
 
@@ -1276,4 +1304,137 @@ def run_keff_vector(reader, mediums, initial_source, settings,
         "k_source_sem": k_src_sem,
         "active_k": active_col,
         "cycles": cycles,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Multiprocessing: independent banks / seeds, one bank per core.
+#
+# Each worker builds its OWN CrossSectionReader (h5py handles are not
+# fork-safe and the cached arrays are large, so sharing one reader across
+# processes is both unsafe and wasteful) via a Pool initializer, and draws
+# from its OWN NumPy generator seeded by SeedSequence.spawn, which guarantees
+# statistically independent streams across workers. Because histories (and,
+# for k-eigenvalue, whole replicas) are independent, the parallel result is
+# the serial result up to the RNG stream, so it is exact in the mean and the
+# batch-means / seed-spread uncertainties remain valid.
+# ---------------------------------------------------------------------------
+
+_WORKER = {}
+
+
+def _init_worker(base_path, temperature):
+    _WORKER["reader"] = CrossSectionReader(base_path, temperature)
+
+
+def _merge_fixed_source(results, src_weight_total):
+    """Concatenate per-history arrays in chunk order and sum the scalars, so
+    the merged result matches a single serial run's return shape and its
+    contiguous batch-means grouping."""
+    leaked_w = np.concatenate([r["leaked_weight"] for r in results])
+    escape_e = np.concatenate([r["escape_energy"] for r in results])
+    absorbed = float(sum(r["absorbed_weight"] for r in results))
+    counters = {}
+    for r in results:
+        for k, v in r["counters"].items():
+            counters[k] = counters.get(k, 0) + v
+    return {
+        "leaked_weight": leaked_w,
+        "escape_energy": escape_e,
+        "leakage": float(leaked_w.sum()) / src_weight_total,
+        "absorbed_weight": absorbed,
+        "counters": counters,
+        "events": max(r["events"] for r in results),
+    }
+
+
+def _fixed_source_worker(args):
+    mediums, chunk, settings, seed, legacy = args
+    reader = _WORKER["reader"]
+    return run_transport(reader, mediums, chunk, np.random.default_rng(seed),
+                         settings, legacy=legacy)
+
+
+def run_transport_parallel(base_path, mediums, source, settings,
+                           n_workers=None, seed=0, temperature="294K",
+                           legacy=None):
+    """Fixed-source transport split across processes, one bank chunk per core.
+
+    ``base_path`` is the ENDF directory (each worker builds its own reader).
+    ``source`` is the usual dict of equal-length arrays. The N histories are
+    partitioned into ``n_workers`` contiguous chunks transported in parallel
+    and merged in order, so the result matches a serial ``run_transport`` in
+    the mean with valid batch-means statistics. Independent per-worker RNG
+    comes from ``SeedSequence(seed).spawn``.
+    """
+    import multiprocessing as mp
+
+    n = int(np.asarray(source["x"]).size)
+    n_workers = n_workers or mp.cpu_count()
+    n_workers = max(1, min(n_workers, n))
+    src_weight_total = float(np.asarray(
+        source.get("weight", np.ones(n)), dtype=float).sum())
+
+    splits = np.array_split(np.arange(n), n_workers)
+    seeds = np.random.SeedSequence(seed).spawn(len(splits))
+    args = []
+    for sl, sd in zip(splits, seeds):
+        chunk = {k: np.asarray(v, dtype=float)[sl] for k, v in source.items()}
+        args.append((mediums, chunk, settings, sd, legacy))
+
+    if n_workers == 1:
+        _init_worker(base_path, temperature)
+        results = [_fixed_source_worker(a) for a in args]
+    else:
+        with mp.Pool(n_workers, initializer=_init_worker,
+                     initargs=(base_path, temperature)) as pool:
+            results = pool.map(_fixed_source_worker, args)
+    return _merge_fixed_source(results, src_weight_total)
+
+
+def _keff_worker(args):
+    mediums, source, settings, gens, inactive, seed = args
+    reader = _WORKER["reader"]
+    return run_keff_vector(reader, mediums, source, settings,
+                           generations=gens, inactive=inactive, seed=seed)
+
+
+def run_keff_parallel(base_path, mediums, sources, settings, seeds,
+                      generations=50, inactive=10, temperature="294K",
+                      n_workers=None):
+    """Independent-replication k-eigenvalue: one power iteration per seed, run
+    in parallel, one replica per core.
+
+    ``sources`` is a list of initial-source dicts (one per replica) and
+    ``seeds`` the matching transport seeds; both have length = number of
+    replicas. Returns the per-seed ``run_keff_vector`` results plus the seed
+    mean and the seed-spread standard error --- the honest error bar for a
+    near-unity dominance-ratio lattice, where the single-run SEM understates
+    the variance (as used for the BEAVRS pin cell).
+    """
+    import multiprocessing as mp
+
+    if len(sources) != len(seeds):
+        raise ValueError("sources and seeds must have the same length")
+    n_workers = n_workers or min(mp.cpu_count(), len(seeds))
+    args = [(mediums, src, settings, generations, inactive, sd)
+            for src, sd in zip(sources, seeds)]
+
+    if n_workers == 1 or len(seeds) == 1:
+        _init_worker(base_path, temperature)
+        results = [_keff_worker(a) for a in args]
+    else:
+        with mp.Pool(n_workers, initializer=_init_worker,
+                     initargs=(base_path, temperature)) as pool:
+            results = pool.map(_keff_worker, args)
+
+    ks = np.array([r["k_eff"] for r in results], dtype=float)
+    k_mean = float(ks.mean())
+    k_spread_sem = (float(ks.std(ddof=1) / np.sqrt(ks.size))
+                    if ks.size > 1 else float("nan"))
+    return {
+        "k_mean": k_mean,
+        "k_spread_sem": k_spread_sem,
+        "per_seed_k": ks.tolist(),
+        "per_seed": results,
     }

--- a/tests/test_vector_transport.py
+++ b/tests/test_vector_transport.py
@@ -401,3 +401,127 @@ def test_keff_vector_matches_scalar():
     assert z < 4.0, (res["k_eff"], res["k_sem"], ref["k_eff"], ref["k_sem"])
     # sanity: near-critical sphere, k in a physically sensible window
     assert 0.95 < res["k_eff"] < 1.10
+
+
+# ---------------------------------------------------------------------------
+# Shared-search cross-section interpolation (perf; must stay exact).
+# ---------------------------------------------------------------------------
+
+def test_interp_shared_matches_numpy():
+    """The one-search interpolation must reproduce np.interp (which the four
+    channels used before) across interior, both extrapolation tails, and
+    exact grid-node energies."""
+    rng = np.random.default_rng(0)
+    grid = np.unique(np.sort(rng.uniform(0, 100, 60)))
+    ys = [rng.uniform(0, 10, len(grid)) for _ in range(4)]
+    E = np.concatenate([rng.uniform(-20, 120, 800), grid,
+                        [grid[0], grid[-1]]])
+    got = vt._interp_shared(E, grid, ys)
+    for g, y in zip(got, ys):
+        np.testing.assert_allclose(g, np.interp(E, grid, y),
+                                   rtol=1e-12, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Multiprocessing wrappers (perf; must stay statistically exact).
+# ---------------------------------------------------------------------------
+
+@needs_data
+def test_run_transport_parallel_matches_serial():
+    """Splitting a fixed-source bank across workers must agree with a serial
+    run within statistics, sum the counters, and preserve per-history length."""
+    from src.settings import Settings
+    from src.statistics import escape_statistics
+
+    reader = CrossSectionReader(ENDF)
+    mat = Material("Fe56", 7.874, 55.845, 55.454)
+    nuc = Nuclide("Fe56", mat.number_density, 55.454)
+    region = Region([Sphere((0, 0, 0), 10.0)], composition=[nuc])
+
+    n = 40000
+    rng = np.random.default_rng(3)
+    mu = rng.uniform(-1, 1, n); phi = rng.uniform(0, 2 * np.pi, n)
+    s = np.sqrt(1 - mu ** 2)
+    src = {"x": np.zeros(n), "y": np.zeros(n), "z": np.zeros(n),
+           "u": s * np.cos(phi), "v": s * np.sin(phi), "w": mu,
+           "energy": np.full(n, 1.0e6)}
+
+    serial = vt.run_transport(reader, [region], dict(src),
+                              np.random.default_rng(1), Settings("shielding", n))
+    par = vt.run_transport_parallel(ENDF, [region], dict(src),
+                                    Settings("shielding", n),
+                                    n_workers=4, seed=1)
+
+    assert par["leaked_weight"].size == n            # every history accounted
+    assert par["counters"]["collisions"] > 0
+    ss = escape_statistics(serial["leaked_weight"], serial["escape_energy"], n)
+    sp = escape_statistics(par["leaked_weight"], par["escape_energy"], n)
+    assert _z(sp["leakage"], sp["leakage_sem"],
+              ss["leakage"], ss["leakage_sem"]) < 4.0
+
+
+@needs_data
+def test_run_transport_parallel_one_worker_is_serial():
+    """n_workers=1 must reproduce a serial run bit-for-bit (same seed, same
+    single spawned stream, no chunk boundary)."""
+    from src.settings import Settings
+
+    reader = CrossSectionReader(ENDF)
+    mat = Material("Pb208", 11.35, 208.0, 206.19)
+    nuc = Nuclide("Pb208", mat.number_density, 206.19)
+    region = Region([Sphere((0, 0, 0), 8.0)], composition=[nuc])
+    n = 3000
+    rng = np.random.default_rng(5)
+    mu = rng.uniform(-1, 1, n); phi = rng.uniform(0, 2 * np.pi, n)
+    s = np.sqrt(1 - mu ** 2)
+    src = {"x": np.zeros(n), "y": np.zeros(n), "z": np.zeros(n),
+           "u": s * np.cos(phi), "v": s * np.sin(phi), "w": mu,
+           "energy": np.full(n, 2.0e6)}
+    par1 = vt.run_transport_parallel(ENDF, [region], dict(src),
+                                     Settings("shielding", n),
+                                     n_workers=1, seed=42)
+    # a bare serial run seeded from the same single spawned child
+    child = np.random.SeedSequence(42).spawn(1)[0]
+    serial = vt.run_transport(reader, [region], dict(src),
+                              np.random.default_rng(child),
+                              Settings("shielding", n))
+    np.testing.assert_array_equal(par1["leaked_weight"], serial["leaked_weight"])
+
+
+@pytest.mark.skipif(
+    not os.path.exists(os.path.join(ENDF, "neutron", "U235.h5")),
+    reason="U235 data not present")
+def test_run_keff_parallel_replications():
+    """Seed-parallel k-eigenvalue returns one k per seed and a seed mean that
+    agrees with a serial replica within statistics."""
+    from src.settings import Settings
+
+    reader = CrossSectionReader(ENDF)
+    rho, amass, awr, radius = 18.74, 235.0, 233.0248, 8.7
+    mat = Material("U235", rho, amass, awr)
+    nuc = Nuclide("U235", mat.number_density, awr, atomic_mass=amass)
+    region = Region([Sphere((0, 0, 0), radius)], composition=[nuc], priority=1)
+
+    def make_source(seed, n=1500):
+        rng = np.random.default_rng(seed)
+        r3 = radius * rng.random(n) ** (1.0 / 3.0)
+        mu = rng.uniform(-1, 1, n); phi = rng.uniform(0, 2 * np.pi, n)
+        s = np.sqrt(1 - mu ** 2)
+        mu2 = rng.uniform(-1, 1, n); phi2 = rng.uniform(0, 2 * np.pi, n)
+        s2 = np.sqrt(1 - mu2 ** 2)
+        return {"x": r3 * s * np.cos(phi), "y": r3 * s * np.sin(phi),
+                "z": r3 * mu, "u": s2 * np.cos(phi2), "v": s2 * np.sin(phi2),
+                "w": mu2, "energy": vt.sample_watt_many(rng, n, 0.988e6, 2.249e-6)}
+
+    seeds = [11, 22, 33]
+    sources = [make_source(100 + s) for s in seeds]
+    out = vt.run_keff_parallel(ENDF, [region], sources, Settings("criticality", 1),
+                               seeds, generations=26, inactive=8, n_workers=3)
+
+    assert len(out["per_seed_k"]) == 3
+    assert 0.9 < out["k_mean"] < 1.15
+    # a serial single-seed replica must sit near the parallel seed mean
+    serial = vt.run_keff_vector(reader, [region], make_source(999),
+                                Settings("criticality", 1),
+                                generations=26, inactive=8, seed=7)
+    assert abs(serial["k_eff"] - out["k_mean"]) < 0.05


### PR DESCRIPTION
Two exac throughput improvements to the event-based engine. The
scalar kernel and all validated results are unchanged.

## Changes
- **Shared cross-section grid search.** `VectorXS` looked up the four reaction
  channels with four separate `np.interp` calls, each redoing the same binary
  search. A new `_interp_shared` does one `searchsorted` + four gathers,
  matching `np.interp` to ~1e-15. ~2.5x on the XS path for a 5-nuclide medium.
- **Multiprocessing wrappers.** `run_transport_parallel` (fixed-source, split
  the bank across cores) and `run_keff_parallel` (independent-replication
  k-eigenvalue, one seed per core, reports the seed-spread SEM). Each worker
  builds its own reader (h5py isn't fork-safe) and draws from an independent
  `SeedSequence` child; `n_workers=1` is bit-identical to serial.

## Performance (single core unless noted)
Fast multi-nuclide XS path ~2.5x; 5-seed pin-cell replication ~4.3x on 6 cores.

## Tests
165 passing (4 new): `_interp_shared` vs `np.interp`; parallel matches serial
within statistics with summed counters; `n_workers=1` bit-identical; seed-
parallel k-eigenvalue returns per-seed k and a consistent mean.
